### PR TITLE
New Setting to Omit Non-Standard Port Numbers During Link Checking

### DIFF
--- a/Diplo.LinkChecker/App_Plugins/Diplo.LinkChecker/Diplo.LinkCheckerController.js
+++ b/Diplo.LinkChecker/App_Plugins/Diplo.LinkChecker/Diplo.LinkCheckerController.js
@@ -17,6 +17,7 @@ angular.module("umbraco")
             $scope.config.onlyShowErrors = false;
             $scope.config.checkEntireDocument = false;
             $scope.config.showSearchBox = false;
+            $scope.config.omitPortDuringChecks = false;
             console.log("Couldn't load config.js - dropping back to defaults...");
             initialise();
         });
@@ -70,7 +71,12 @@ angular.module("umbraco")
                         $http({
                             url: checkLinksUrl + data[i],
                             method: "GET",
-                            params: { checkEntireDocument: $scope.config.checkEntireDocument, timeout: $scope.config.timeout, hideDuplicates: $scope.config.hideDuplicates }
+                            params: { 
+                                checkEntireDocument: $scope.config.checkEntireDocument, 
+                                timeout: $scope.config.timeout, 
+                                hideDuplicates: $scope.config.hideDuplicates,
+                                omitPortDuringChecks: $scope.config.omitPortDuringChecks
+                            }
                         }).
                           success(function (data, status, headers, config) {
 

--- a/Diplo.LinkChecker/App_Plugins/Diplo.LinkChecker/config.js
+++ b/Diplo.LinkChecker/App_Plugins/Diplo.LinkChecker/config.js
@@ -3,6 +3,7 @@
           "timeout": 30,                        
           "onlyShowErrors": false,              
           "checkEntireDocument": false,
-          "showSearchBox" : false
+          "showSearchBox": false,
+          "omitPortDuringChecks": false
       }
 ]

--- a/Diplo.LinkChecker/Controllers/LinkCheckerController.cs
+++ b/Diplo.LinkChecker/Controllers/LinkCheckerController.cs
@@ -30,7 +30,7 @@ namespace Diplo.LinkChecker.Controllers
         /// /Umbraco/Backoffice/Api/LinkChecker/CheckPage/1073
         /// </remarks>
         [HttpGet]
-        public async Task<CheckedPage> CheckPage(int id, bool checkEntireDocument = false, int timeout = 30)
+        public async Task<CheckedPage> CheckPage(int id, bool checkEntireDocument = false, int timeout = 30, bool omitPortDuringChecks = false)
         {
             var node = Umbraco.TypedContent(id);
 
@@ -51,7 +51,7 @@ namespace Diplo.LinkChecker.Controllers
 
             string html = await checker.GetHtmlFromUrl(new Uri(node.UrlAbsolute()));
 
-            HtmlParsingService parser = new HtmlParsingService(new Uri(Request.RequestUri.GetLeftPart(UriPartial.Authority)));
+            HtmlParsingService parser = new HtmlParsingService(new Uri(Request.RequestUri.GetLeftPart(UriPartial.Authority)), omitPortDuringChecks);
             parser.CheckEntireDocument = checkEntireDocument;
 
             var links = parser.GetLinksFromHtmlDocument(html);

--- a/Diplo.LinkChecker/Controllers/LinkCheckerController.cs
+++ b/Diplo.LinkChecker/Controllers/LinkCheckerController.cs
@@ -51,7 +51,7 @@ namespace Diplo.LinkChecker.Controllers
 
             string html = await checker.GetHtmlFromUrl(new Uri(node.UrlAbsolute()));
 
-            HtmlParsingService parser = new HtmlParsingService(new Uri(Request.RequestUri.GetLeftPart(UriPartial.Authority)), omitPortDuringChecks);
+            HtmlParsingService parser = new HtmlParsingService(new Uri(Request.RequestUri.GetLeftPart(UriPartial.Authority)), !omitPortDuringChecks);
             parser.CheckEntireDocument = checkEntireDocument;
 
             var links = parser.GetLinksFromHtmlDocument(html);

--- a/Diplo.LinkChecker/Services/HtmlParsingService.cs
+++ b/Diplo.LinkChecker/Services/HtmlParsingService.cs
@@ -18,14 +18,12 @@ namespace Diplo.LinkChecker.Services
         /// Initializes a new instance of the <see cref="HtmlParsingService"/> class from the base URL of the site
         /// </summary>
         /// <param name="baseUri">The base URI of the site being checked</param>
-        public HtmlParsingService(Uri baseUri)
+        /// <param name="allowNonStandardPortInBaseUri">If true, when checking links found in a document, a non-standard port be omitted from the request.</param>
+        public HtmlParsingService(Uri baseUri, bool allowNonStandardPortInBaseUri = true)
         {
-            if (baseUri == null)
-            {
-                throw new ArgumentNullException("The base URL of the site being checked cannot be null");
-            }
+            if (baseUri == null) throw new ArgumentNullException("The base URL of the site being checked cannot be null");
 
-            this.BaseUri = baseUri;
+            this.BaseUri = allowNonStandardPortInBaseUri ? baseUri : new UriBuilder(baseUri) { Port = -1 }.Uri;
         }
 
         private static Regex MatchProtocolRegex = new Regex(@"^\w{3,8}://*", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Hi Dan, 

Sorry for the multiple commits. I am not tooled for Git on this computer (and not that skilled with Git yet) so I used the github UI to do all of the changes. 

I tried to implement this new setting using your current configuration scheme with config.js. This caused me to have to pass it through multiple layers but I would rather do that than to introduce numerous ways to configure LinkChecker.

Thanks, 

Ben
