### PR TITLE
Improve the response decoding

### DIFF
--- a/Diplo.LinkChecker/Services/HttpCheckerService.cs
+++ b/Diplo.LinkChecker/Services/HttpCheckerService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.Caching;
+using System.Text;
 using System.Threading.Tasks;
 using Diplo.LinkChecker.Models;
 
@@ -79,7 +80,21 @@ namespace Diplo.LinkChecker.Services
                         {
                             if (response.IsSuccessStatusCode)
                             {
-                                return await response.Content.ReadAsStringAsync();
+                                string content = string.Empty;
+
+                                if (!string.IsNullOrWhiteSpace(response.Content.Headers.ContentType.CharSet))
+                                {
+                                    var buffer = await response.Content.ReadAsByteArrayAsync();
+                                    var enconding = Encoding.GetEncoding(response.Content.Headers.ContentType.CharSet);
+
+                                    return WebUtility.HtmlDecode(enconding.GetString(buffer));
+                                }
+                                else
+                                {
+                                    content = await response.Content.ReadAsStringAsync();
+
+                                    return WebUtility.HtmlDecode(content);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When working on sites using special characters such as diacritics (pretty common in language such as "French"), the HTML of the response was not decoded, so diacritics were encoded. 

Therefore, when the response was parsed and links accessed, the one with diacritics resulted in error because of the diacritics encoding.

This PR improves the code by:

- Parsing the response according to its charset (if available)
- Decode the HTML